### PR TITLE
Update TSP_AR_VFE_SHUTITDOWN.xml

### DIFF
--- a/1.4/Patches/TSP_AR_VFE_SHUTITDOWN.xml
+++ b/1.4/Patches/TSP_AR_VFE_SHUTITDOWN.xml
@@ -124,7 +124,7 @@
                 <Cleanliness>0</Cleanliness>
               </statBases>
               <graphicData Inherit="False">
-                <texPath>Things/Item/Resource/Bronze</texPath>
+                <texPath>Things/Item/Resource/Silver</texPath> <!-- Close enough -->
                 <graphicClass>Graphic_Single</graphicClass>
                 <color>(132,80,52)</color>
               </graphicData>


### PR DESCRIPTION
**_RESOLUTION OF THIS ERROR:_**

Could not load UnityEngine.Texture2D at Things/Item/Resource/Bronze in any active mod or in base resources. UnityEngine.StackTraceUtility:ExtractStackTrace () (wrapper dynamic-method) Verse.Log:Verse.Log.Error_Patch5 (string) Verse.ContentFinder`1<UnityEngine.Texture2D>:Get (string,bool) Verse.Graphic_Single:Init (Verse.GraphicRequest)
Verse.GraphicDatabase:GetInner<Verse.Graphic_Single> (Verse.GraphicRequest) Verse.GraphicDatabase:Get (Verse.GraphicRequest)
Verse.GraphicDatabase:Get (System.Type,string,UnityEngine.Shader,UnityEngine.Vector2,UnityEngine.Color,UnityEngine.Color,Verse.GraphicData,System.Collections.Generic.List`1<Verse.ShaderParameter>,string) Verse.GraphicData:Init ()
Verse.GraphicData:get_Graphic ()
Verse.ThingDef:<PostLoad>b__349_0 ()
Verse.LongEventHandler:ExecuteToExecuteWhenFinished () Verse.LongEventHandler:UpdateCurrentAsynchronousEvent () Verse.LongEventHandler:LongEventsUpdate (bool&)
(wrapper dynamic-method) Verse.Root:Verse.Root.Update_Patch1 (Verse.Root) Verse.Root_Entry:Update ()